### PR TITLE
[FRONTEND] [REFACTO] Optimize rendering with partial GPU texture uplo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ config/providers.json
 
 # Vim session files
 Session.vim
+.editorconfig
 
 # Local agent memory (kept out of the repo)
 memories/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,7 +30,7 @@ services:
         - action: sync
           path: src/
           target: /app/src
-        
+
         - action: sync
           path: public/
           target: /app/public

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,9 +6,11 @@ import pluginReact from "eslint-plugin-react";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 
 // Sources ending in a stylesheet/asset extension (incl. ?query suffix, e.g. .svg?react).
-const ASSET = "\\.(css|scss|sass|less|svg|png|jpe?g|gif|webp|glsl|mp3|wav|ogg)(\\?\\w+)?$";
+const ASSET =
+  "\\.(css|scss|sass|less|svg|png|jpe?g|gif|webp|glsl|mp3|wav|ogg)(\\?\\w+)?$";
 // Project path aliases (see tsconfig.paths.json), to tell them apart from npm @scope packages.
-const PROJECT = "@(modules|shared|components|providers|hooks|utils|theme|api|errors|assets|lib|typedefs)(/|$)";
+const PROJECT =
+  "@(modules|shared|components|providers|hooks|utils|theme|api|errors|assets|lib|typedefs)(/|$)";
 
 export default defineConfig([
   {
@@ -17,8 +19,8 @@ export default defineConfig([
       globals: globals.browser,
       parser: tseslint.parser,
       parserOptions: {
-        project: "./tsconfig.eslint.json"
-      }
+        project: "./tsconfig.eslint.json",
+      },
     },
     plugins: {
       js,
@@ -28,7 +30,9 @@ export default defineConfig([
     },
     extends: ["js/recommended"],
     rules: {
-      indent: ["error", 2, { "SwitchCase": 1 }],
+      indent: ["error", 2, { SwitchCase: 1 }],
+      "react/jsx-indent": ["error", 2],
+      "react/jsx-indent-props": ["error", 2],
       quotes: ["error", "double"],
       "@typescript-eslint/no-unused-vars": "warn",
       /* "no-console": "warn", */
@@ -37,38 +41,54 @@ export default defineConfig([
       "no-var": "error",
       "prefer-const": "error",
       "object-curly-spacing": ["error", "always"],
-      "comma-spacing": ["error", { "before": false, "after": true }],
-      "semi": ["error", "always"],
-      "@typescript-eslint/explicit-function-return-type": ["error", {
-        allowExpressions: true,
-        allowTypedFunctionExpressions: true,
-      }],
+      "comma-spacing": ["error", { before: false, after: true }],
+      semi: ["error", "always"],
+      "@typescript-eslint/explicit-function-return-type": [
+        "error",
+        {
+          allowExpressions: true,
+          allowTypedFunctionExpressions: true,
+        },
+      ],
       "eol-last": ["error", "always"],
-      "no-multiple-empty-lines": ["error", { "max": 1 }],
+      "no-multiple-empty-lines": ["error", { max: 1 }],
       "no-trailing-spaces": ["error"],
       // Ordered import groups: project aliases, project relative, react,
       // other libraries, node builtins, then styles & assets last.
-      "simple-import-sort/imports": ["error", {
-        groups: [
-          [`^(?!.*${ASSET})${PROJECT}`],
-          [`^(?!.*${ASSET})\\.`],
-          ["^react(-dom)?(/|$)"],
-          [`^(?!node:)(?!.*${ASSET})@?\\w`],
-          ["^node:"],
-          [ASSET],
-        ],
-      }],
+      "simple-import-sort/imports": [
+        "error",
+        {
+          groups: [
+            [`^(?!.*${ASSET})${PROJECT}`],
+            [`^(?!.*${ASSET})\\.`],
+            ["^react(-dom)?(/|$)"],
+            [`^(?!node:)(?!.*${ASSET})@?\\w`],
+            ["^node:"],
+            [ASSET],
+          ],
+        },
+      ],
       // Enforce the alias policy: no raw src/ imports, no file extensions.
-      "no-restricted-imports": ["error", {
-        patterns: [
-          { group: ["src/*", "src/**"], message: "Use a path alias (e.g. @shared, @modules) instead of a raw src/ import." },
-          { group: ["**/*.ts", "**/*.tsx"], message: "Omit the .ts/.tsx file extension in import paths." },
-        ],
-      }],
-    }
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["src/*", "src/**"],
+              message:
+                "Use a path alias (e.g. @shared, @modules) instead of a raw src/ import.",
+            },
+            {
+              group: ["**/*.ts", "**/*.tsx"],
+              message: "Omit the .ts/.tsx file extension in import paths.",
+            },
+          ],
+        },
+      ],
+    },
   },
   tseslint.configs.recommended,
   {
-    ignores: ["src/api/*"]
-  }
+    ignores: ["src/api/*", "eslint.config.js"],
+  },
 ]);

--- a/src/modules/create/game-editor/editors/sprite-editor/Color.tsx
+++ b/src/modules/create/game-editor/editors/sprite-editor/Color.tsx
@@ -19,5 +19,17 @@ export const colorPalette: Color[] = [
   { name: "blue", hex: "#29ADFF" },
   { name: "lavender", hex: "#83769C" },
   { name: "pink", hex: "#FF77A8" },
-  { name: "peach", hex: "#FFCCAA" }
+  { name: "peach", hex: "#FFCCAA" },
 ];
+
+export const webglPaletteBuffer = new Uint8Array(
+  colorPalette.flatMap((c) => {
+    const hex = c.hex.replace("#", "");
+    return [
+      parseInt(hex.substring(0, 2), 16),
+      parseInt(hex.substring(2, 4), 16),
+      parseInt(hex.substring(4, 6), 16),
+      255,
+    ];
+  }),
+);

--- a/src/modules/create/game-editor/editors/sprite-editor/Color.tsx
+++ b/src/modules/create/game-editor/editors/sprite-editor/Color.tsx
@@ -19,7 +19,7 @@ export const colorPalette: Color[] = [
   { name: "blue", hex: "#29ADFF" },
   { name: "lavender", hex: "#83769C" },
   { name: "pink", hex: "#FF77A8" },
-  { name: "peach", hex: "#FFCCAA" },
+  { name: "peach", hex: "#FFCCAA" }
 ];
 
 export const webglPaletteBuffer = new Uint8Array(

--- a/src/modules/create/game-editor/editors/sprite-editor/SpriteEditor.tsx
+++ b/src/modules/create/game-editor/editors/sprite-editor/SpriteEditor.tsx
@@ -167,6 +167,7 @@ const ColorSelector = styled("div")(({ theme }) => ({
   borderRadius: theme.shape.borderRadius,
   height: "fit-content",
   alignContent: "start",
+  flexShrink: 0,
   overflowY: "auto",
   overflowX: "hidden",
   scrollbarWidth: "thin",

--- a/src/modules/create/game-editor/editors/sprite-editor/SpriteEditor.tsx
+++ b/src/modules/create/game-editor/editors/sprite-editor/SpriteEditor.tsx
@@ -1,5 +1,8 @@
 import { EditorProps } from "@modules/create/game-editor/editors/EditorType";
-import Tools, { SpritePixelAccessor } from "@modules/create/game-editor/editors/sprite-editor/Tools";
+import Tools, {
+  SpritePixelAccessor,
+} from "@modules/create/game-editor/editors/sprite-editor/Tools";
+import { PixelChange } from "@providers/editors/SpriteProvider";
 import { StyledCanvas } from "@shared/canvas/Canvas";
 import CanvasGridOverlay from "@shared/canvas/CanvasGridOverlay";
 import { SpriteRendererHandle } from "@shared/canvas/RendererHandle";
@@ -17,14 +20,18 @@ export enum DrawTool {
   Fill,
   Line, // TODO
   Rectangle, // TODO
-  Circle
+  Circle,
 }
 export type CanvasHandler = ((pixelPos: Point2D) => void) | undefined;
-export type PreviewOverlay = (renderer: SpriteRendererHandle, offsetX: number, offsetY: number) => void;
+export type PreviewOverlay = (
+  renderer: SpriteRendererHandle,
+  offsetX: number,
+  offsetY: number,
+) => void;
 
 const TILE_SIZES = Array.from({ length: 8 }, (_, i) => (i + 1) * 8);
 const BIT_INDICES = [0, 1, 2, 3, 4, 5, 6, 7] as const;
-type TileSize = typeof TILE_SIZES[number];
+type TileSize = (typeof TILE_SIZES)[number];
 
 interface ColorButtonProps {
   color: { name: string; hex: string };
@@ -32,7 +39,11 @@ interface ColorButtonProps {
   onClick: () => void;
 }
 
-const ColorButton: React.FC<ColorButtonProps> = ({ color, isSelected, onClick }) => (
+const ColorButton: React.FC<ColorButtonProps> = ({
+  color,
+  isSelected,
+  onClick,
+}) => (
   <ColorButtonStyled
     key={color.name}
     onClick={onClick}
@@ -48,7 +59,11 @@ interface ColorPaletteProps {
   onColorSelect: (index: number) => void;
 }
 
-const ColorPalette: React.FC<ColorPaletteProps> = ({ colors, currentColor, onColorSelect }) => (
+const ColorPalette: React.FC<ColorPaletteProps> = ({
+  colors,
+  currentColor,
+  onColorSelect,
+}) => (
   <ColorSelector>
     {colors.map((color, index) => (
       <ColorButton
@@ -81,7 +96,9 @@ const ToolBar = styled("div")(({ theme }) => ({
 const CanvasColumns = styled("div")(({ theme }) => ({
   gap: theme.spacing(2),
   width: "100%",
-  flex: 2.0
+  flex: 2.0,
+  display: "flex",
+  flexDirection: "column",
 }));
 
 const Panel = styled("section")(() => ({
@@ -92,6 +109,7 @@ const Panel = styled("section")(() => ({
 const FillPanel = styled("section")({
   width: "100%",
   minHeight: 0,
+  flex: 1,
 });
 
 const HPanel = styled("section")(() => ({
@@ -180,11 +198,13 @@ const CanvasViewport = styled("div")(({ theme }) => ({
 }));
 
 const SpritePickerViewport = styled(CanvasViewport)({
-  height: "100%",
+  width: "100%",
   aspectRatio: "1",
   minHeight: 0,
-  flex: 1,
-  display: "flex",
+});
+
+const DetailCanvasViewport = styled(CanvasViewport)({
+  height: "100%",
 });
 
 function clamp(value: number, min: number, max: number): number {
@@ -195,7 +215,7 @@ function getCanvasPixelPos(
   e: React.MouseEvent<HTMLCanvasElement, MouseEvent>,
   rect: DOMRect,
   width: number,
-  height: number
+  height: number,
 ): Point2D {
   const normalizedX = clamp((e.clientX - rect.left) / rect.width, 0, 1);
   const normalizedY = clamp((e.clientY - rect.top) / rect.height, 0, 1);
@@ -221,6 +241,8 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
   const selectionCanvasRef = useRef<SpriteRendererHandle | null>(null);
   const detailCanvasRef = useRef<SpriteRendererHandle | null>(null);
 
+  const detailRafPending = useRef(false);
+
   const setOnMouseDown = useCallback((fn: CanvasHandler) => {
     onMouseDownRef.current = fn;
   }, []);
@@ -238,21 +260,31 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
   const sheetHeight = project.spriteProvider.size.height;
   const baseSpriteWidth = project.spriteProvider.spriteSize.width;
   const baseSpriteHeight = project.spriteProvider.spriteSize.height;
-  const selectionScreenSize = useMemo(() => ({
-    width: sheetWidth,
-    height: sheetHeight,
-  }), [sheetHeight, sheetWidth]);
-  const detailScreenSize = useMemo(() => ({
-    width: tileSize,
-    height: tileSize,
-  }), [tileSize]);
+  const selectionScreenSize = useMemo(
+    () => ({
+      width: sheetWidth,
+      height: sheetHeight,
+    }),
+    [sheetHeight, sheetWidth],
+  );
+  const detailScreenSize = useMemo(
+    () => ({
+      width: tileSize,
+      height: tileSize,
+    }),
+    [tileSize],
+  );
   const spritesPerRow = sheetWidth / baseSpriteWidth;
-  const spritesPerCol = project.spriteProvider.size.height / project.spriteProvider.spriteSize.height;
+  const spritesPerCol =
+    project.spriteProvider.size.height /
+    project.spriteProvider.spriteSize.height;
 
   const tileSpriteSpanWidth = tileSize / baseSpriteWidth;
   const tileSpriteSpanHeight = tileSize / baseSpriteHeight;
 
-  const selectedTileIndex = (selectedTile.y / baseSpriteHeight) * spritesPerRow + (selectedTile.x / baseSpriteWidth);
+  const selectedTileIndex =
+    (selectedTile.y / baseSpriteHeight) * spritesPerRow +
+    selectedTile.x / baseSpriteWidth;
   const selectedSpriteX = selectedTileIndex % spritesPerRow;
   const selectedSpriteY = Math.floor(selectedTileIndex / spritesPerRow);
 
@@ -260,7 +292,13 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
     const handle = selectionCanvasRef.current;
     if (!handle) return;
 
-    handle.queueSpriteDraw(0, 0, 0, spritesPerRow, sheetHeight / baseSpriteHeight);
+    handle.queueSpriteDraw(
+      0,
+      0,
+      0,
+      spritesPerRow,
+      sheetHeight / baseSpriteHeight,
+    );
     handle.draw();
   }, [baseSpriteHeight, sheetHeight, spritesPerRow]);
 
@@ -268,39 +306,123 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
     const handle = detailCanvasRef.current;
     if (!handle) return;
 
-    handle.queueSpriteDraw(selectedTileIndex, 0, 0, tileSpriteSpanWidth, tileSpriteSpanHeight);
+    handle.queueSpriteDraw(
+      selectedTileIndex,
+      0,
+      0,
+      tileSpriteSpanWidth,
+      tileSpriteSpanHeight,
+    );
     handle.draw();
     previewOverlayRef.current?.(handle, selectedTile.x, selectedTile.y);
-  }, [selectedTile.x, selectedTile.y, selectedTileIndex, tileSpriteSpanHeight, tileSpriteSpanWidth]);
+  }, [
+    selectedTile.x,
+    selectedTile.y,
+    selectedTileIndex,
+    tileSpriteSpanHeight,
+    tileSpriteSpanWidth,
+  ]);
+
+  const scheduleDetailDraw = useCallback((): void => {
+    if (detailRafPending.current) return;
+    detailRafPending.current = true;
+    requestAnimationFrame(() => {
+      if (!detailRafPending.current) {
+        return;
+      }
+      detailRafPending.current = false;
+      drawDetailCanvas();
+    });
+  }, [drawDetailCanvas]);
+
+  const cancelScheduledDetailDraw = useCallback((): void => {
+    detailRafPending.current = false;
+  }, []);
 
   const redraw = useCallback((): void => {
     drawDetailCanvas();
     drawSelectionCanvas();
   }, [drawDetailCanvas, drawSelectionCanvas]);
 
-  const setSelectionCanvasHandle = useCallback((handle: SpriteRendererHandle | null) => {
-    selectionCanvasRef.current = handle;
-    if (handle) {
-      redraw();
-    }
-  }, [redraw]);
+  const setSelectionCanvasHandle = useCallback(
+    (handle: SpriteRendererHandle | null) => {
+      selectionCanvasRef.current = handle;
+      if (handle) {
+        redraw();
+      }
+    },
+    [redraw],
+  );
 
-  const setDetailCanvasHandle = useCallback((handle: SpriteRendererHandle | null) => {
-    detailCanvasRef.current = handle;
-    if (handle) {
-      redraw();
-    }
-  }, [redraw]);
+  const setDetailCanvasHandle = useCallback(
+    (handle: SpriteRendererHandle | null) => {
+      detailCanvasRef.current = handle;
+      if (handle) {
+        redraw();
+      }
+    },
+    [redraw],
+  );
 
   useEffect(() => {
-    project.spriteProvider.observe(redraw);
-    project.spriteProvider.observeFlags(() => setFlagVersion((value) => value + 1));
-  }, [project, redraw]);
+    const handlePixelChanges = (changes: PixelChange[]): void => {
+      let touchesSelectedTile = false;
+      const affectedTiles = new Set<number>();
+
+      for (const { x, y } of changes) {
+        const tileX = Math.floor(x / baseSpriteWidth) * baseSpriteWidth;
+        const tileY = Math.floor(y / baseSpriteHeight) * baseSpriteHeight;
+
+        if (tileX === selectedTile.x && tileY === selectedTile.y) {
+          touchesSelectedTile = true;
+        }
+
+        const tileIndex =
+          (tileY / baseSpriteHeight) * spritesPerRow + tileX / baseSpriteWidth;
+        affectedTiles.add(tileIndex);
+      }
+
+      if (touchesSelectedTile) {
+        scheduleDetailDraw();
+      }
+
+      drawSelectionCanvas();
+    };
+
+    const handleFlagChanges = (): void => {
+      setFlagVersion((value) => value + 1);
+    };
+
+    project.spriteProvider.observe(handlePixelChanges);
+    project.spriteProvider.observeFlags(handleFlagChanges);
+
+    return () => {
+      project.spriteProvider.unobserve(handlePixelChanges);
+      project.spriteProvider.unobserveFlags(handleFlagChanges);
+    };
+  }, [
+    project,
+    baseSpriteWidth,
+    baseSpriteHeight,
+    spritesPerRow,
+    selectedTile.x,
+    selectedTile.y,
+    scheduleDetailDraw,
+    drawSelectionCanvas,
+  ]);
 
   useEffect(() => {
     setSelectedTile((prevTile) => ({
-      x: clamp(Math.floor(prevTile.x / baseSpriteWidth) * baseSpriteWidth, 0, sheetWidth - baseSpriteWidth),
-      y: clamp(Math.floor(prevTile.y / baseSpriteHeight) * baseSpriteHeight, 0, sheetHeight - baseSpriteHeight),
+      x: clamp(
+        Math.floor(prevTile.x / baseSpriteWidth) * baseSpriteWidth,
+        0,
+        sheetWidth - baseSpriteWidth,
+      ),
+      y: clamp(
+        Math.floor(prevTile.y / baseSpriteHeight) * baseSpriteHeight,
+        0,
+        sheetHeight - baseSpriteHeight,
+      ),
     }));
     isDrawingRef.current = false;
   }, [baseSpriteHeight, baseSpriteWidth, sheetHeight, sheetWidth, tileSize]);
@@ -312,7 +434,8 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
     const maxY = minY + tileSize;
 
     return {
-      isPixelInBounds: (x: number, y: number) => x >= minX && x < maxX && y >= minY && y < maxY,
+      isPixelInBounds: (x: number, y: number) =>
+        x >= minX && x < maxX && y >= minY && y < maxY,
       getPixel: (x: number, y: number) => project.spriteProvider.getPixel(x, y),
       setPixel: (x: number, y: number, color: number) => {
         if (x < minX || x >= maxX || y < minY || y >= maxY) {
@@ -320,6 +443,7 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
         }
         project.spriteProvider.setPixel(x, y, color);
       },
+      transact: (fn) => project.spriteProvider.transact(fn),
     };
   }, [project.spriteProvider, selectedTile.x, selectedTile.y, tileSize]);
 
@@ -336,58 +460,81 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
     const { x, y } = getCanvasPixelPos(e, rect, sheetWidth, sheetHeight);
 
     setSelectedTile({
-      x: clamp(Math.floor(x / baseSpriteWidth) * baseSpriteWidth, 0, sheetWidth - baseSpriteWidth),
-      y: clamp(Math.floor(y / baseSpriteHeight) * baseSpriteHeight, 0, sheetHeight - baseSpriteHeight),
+      x: clamp(
+        Math.floor(x / baseSpriteWidth) * baseSpriteWidth,
+        0,
+        sheetWidth - baseSpriteWidth,
+      ),
+      y: clamp(
+        Math.floor(y / baseSpriteHeight) * baseSpriteHeight,
+        0,
+        sheetHeight - baseSpriteHeight,
+      ),
     });
   };
 
-  const toSelectedTilePixel = useCallback((
-    e: React.MouseEvent<HTMLCanvasElement, MouseEvent>
-  ): Point2D => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const localPos = getCanvasPixelPos(e, rect, tileSize, tileSize);
+  const toSelectedTilePixel = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement, MouseEvent>): Point2D => {
+      const rect = e.currentTarget.getBoundingClientRect();
+      const localPos = getCanvasPixelPos(e, rect, tileSize, tileSize);
 
-    return {
-      x: selectedTile.x + localPos.x,
-      y: selectedTile.y + localPos.y,
-    };
-  }, [selectedTile.x, selectedTile.y, tileSize]);
+      return {
+        x: selectedTile.x + localPos.x,
+        y: selectedTile.y + localPos.y,
+      };
+    },
+    [selectedTile.x, selectedTile.y, tileSize],
+  );
 
-  const handleEditorMouseDown = (e: React.MouseEvent<HTMLCanvasElement>): void => {
+  const handleEditorMouseDown = (
+    e: React.MouseEvent<HTMLCanvasElement>,
+  ): void => {
     if (e.button !== 0) return;
 
     isDrawingRef.current = true;
     onMouseDownRef.current?.(toSelectedTilePixel(e));
-    redraw();
+    scheduleDetailDraw();
   };
 
-  const handleEditorMouseMove = (e: React.MouseEvent<HTMLCanvasElement>): void => {
+  const handleEditorMouseMove = (
+    e: React.MouseEvent<HTMLCanvasElement>,
+  ): void => {
     if (!isDrawingRef.current) return;
 
     onMouseMoveRef.current?.(toSelectedTilePixel(e));
-    redraw();
+    scheduleDetailDraw();
   };
 
-  const handleEditorMouseUp = (e: React.MouseEvent<HTMLCanvasElement>): void => {
+  const handleEditorMouseUp = (
+    e: React.MouseEvent<HTMLCanvasElement>,
+  ): void => {
     if (e.button !== 0) return;
 
     if (isDrawingRef.current) {
       onMouseUpRef.current?.(toSelectedTilePixel(e));
+      cancelScheduledDetailDraw();
       redraw();
     }
     isDrawingRef.current = false;
   };
 
-  const handleEditorMouseLeave = (e: React.MouseEvent<HTMLCanvasElement>): void => {
+  const handleEditorMouseLeave = (
+    e: React.MouseEvent<HTMLCanvasElement>,
+  ): void => {
     if (!isDrawingRef.current) return;
 
     onMouseUpRef.current?.(toSelectedTilePixel(e));
     isDrawingRef.current = false;
+    cancelScheduledDetailDraw();
     redraw();
   };
 
   const handleBitToggle = (bit: number): void => {
-    project.spriteProvider.setFlagBit(selectedTileIndex, bit, !project.spriteProvider.getFlagBit(selectedTileIndex, bit));
+    project.spriteProvider.setFlagBit(
+      selectedTileIndex,
+      bit,
+      !project.spriteProvider.getFlagBit(selectedTileIndex, bit),
+    );
   };
 
   const handleTileSizeWheel = (e: React.WheelEvent<HTMLDivElement>): void => {
@@ -402,10 +549,7 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
   };
 
   return (
-    <EditorLayout
-      onContextMenu={handleContextMenu}
-      data-cy="sprite-editor"
-    >
+    <EditorLayout onContextMenu={handleContextMenu} data-cy="sprite-editor">
       <ToolBar>
         <HPanel>
           <ColorPalette
@@ -436,7 +580,10 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
                 <BitButton
                   key={bit}
                   type="button"
-                  $active={project.spriteProvider.getFlagBit(selectedTileIndex, bit)}
+                  $active={project.spriteProvider.getFlagBit(
+                    selectedTileIndex,
+                    bit,
+                  )}
                   onClick={() => handleBitToggle(bit)}
                 >
                   {bit}
@@ -450,6 +597,8 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
           <SpritePickerViewport onWheel={handleTileSizeWheel}>
             <StyledCanvas
               ref={setSelectionCanvasHandle}
+              width={selectionScreenSize.width}
+              height={selectionScreenSize.height}
               sprite={project.spriteProvider}
               map={project.mapProvider}
               sound={project.soundProvider}
@@ -457,7 +606,7 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
               onClick={handleTileSelect}
               style={{
                 width: "100%",
-                height: "100%",
+                height: "auto",
               }}
             />
             <CanvasGridOverlay
@@ -468,8 +617,8 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
             <SelectedSpriteFrame
               $left={`${(selectedSpriteX / spritesPerRow) * 100}%`}
               $top={`${(selectedSpriteY / spritesPerCol) * 100}%`}
-              $width={`${(100 / spritesPerRow) * tileSize / 8}%`}
-              $height={`${(100 / spritesPerCol) * tileSize / 8}%`}
+              $width={`${((100 / spritesPerRow) * tileSize) / 8}%`}
+              $height={`${((100 / spritesPerCol) * tileSize) / 8}%`}
             />
           </SpritePickerViewport>
         </Panel>
@@ -477,9 +626,11 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
 
       <CanvasColumns>
         <FillPanel>
-          <CanvasViewport onWheel={handleTileSizeWheel}>
+          <DetailCanvasViewport onWheel={handleTileSizeWheel}>
             <StyledCanvas
               ref={setDetailCanvasHandle}
+              width={detailScreenSize.width}
+              height={detailScreenSize.height}
               sprite={project.spriteProvider}
               map={project.mapProvider}
               screenSize={detailScreenSize}
@@ -490,7 +641,7 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
               onMouseLeave={handleEditorMouseLeave}
               style={{
                 width: "100%",
-                height: "100%"
+                height: "100%",
               }}
             />
             <CanvasGridOverlay
@@ -498,7 +649,7 @@ export const SpriteEditor: React.FC<EditorProps> = ({ project }) => {
               rows={tileSize}
               lineColor="rgba(255, 255, 255, 0.20)"
             />
-          </CanvasViewport>
+          </DetailCanvasViewport>
         </FillPanel>
       </CanvasColumns>
     </EditorLayout>

--- a/src/modules/create/game-editor/editors/sprite-editor/Tools.tsx
+++ b/src/modules/create/game-editor/editors/sprite-editor/Tools.tsx
@@ -1,25 +1,28 @@
-import {
-  CanvasHandler,
-  DrawTool,
-  PreviewOverlay,
-} from "@modules/create/game-editor/editors/sprite-editor/SpriteEditor";
+import { CanvasHandler, DrawTool, PreviewOverlay } from "@modules/create/game-editor/editors/sprite-editor/SpriteEditor";
 import { SpriteProvider } from "@providers/editors/SpriteProvider";
 
 import React, { useEffect, useRef, useState } from "react";
 
 import { styled } from "@mui/material";
 
-export type SpritePixelAccessor = Pick<
-  SpriteProvider,
-  "isPixelInBounds" | "getPixel" | "setPixel"
-> & {
+export type SpritePixelAccessor = Pick<SpriteProvider, "isPixelInBounds" | "getPixel" | "setPixel"> & {
   transact?: (fn: () => void) => void;
 };
 
 const Container = styled("div")(() => ({
+  display: "contents",
+}));
+
+const ButtonRow = styled("div")(() => ({
   display: "flex",
   gap: 8,
-  alignItems: "center",
+  alignItems: "flex-start",
+}));
+
+const CircleGroup = styled("div")(() => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: 4,
 }));
 
 const ToolButton = styled("button")(({ theme }) => ({
@@ -37,16 +40,7 @@ const Tools: React.FC<{
   setOnMouseUp?: (fn: CanvasHandler) => void;
   setOnMouseDown?: (fn: CanvasHandler) => void;
   setPreviewOverlay?: (fn: PreviewOverlay | null) => void;
-}> = ({
-  drawTool,
-  onSelectTool,
-  setOnMouseDown,
-  setOnMouseMove,
-  setOnMouseUp,
-  setPreviewOverlay,
-  spriteProvider,
-  color,
-}) => {
+}> = ({ drawTool, onSelectTool, setOnMouseDown, setOnMouseMove, setOnMouseUp, setPreviewOverlay, spriteProvider, color }) => {
   const lastPosRef = useRef<Point2D | null>(null);
   const colorRef = useRef(color);
   const [fillCircle, setFillCircle] = useState(false);
@@ -124,7 +118,9 @@ const Tools: React.FC<{
           spriteProvider.setPixel(x0, y0, colorRef.current);
         }
 
-        if (x0 === x1 && y0 === y1) break;
+        if (x0 === x1 && y0 === y1) {
+          break;
+        }
         const e2 = err * 2;
         if (e2 > -dy) {
           err -= dy;
@@ -138,24 +134,13 @@ const Tools: React.FC<{
     });
   };
 
-  const drawHLine = (
-    x1: number,
-    x2: number,
-    y: number,
-    color: number,
-  ): void => {
+  const drawHLine = (x1: number, x2: number, y: number, color: number): void => {
     for (let x = x1; x <= x2; x++) {
       spriteProvider.setPixel(x, y, color);
     }
   };
 
-  const plotCirclePoints = (
-    xc: number,
-    yc: number,
-    x: number,
-    y: number,
-    color: number,
-  ): void => {
+  const plotCirclePoints = (xc: number, yc: number, x: number, y: number, color: number): void => {
     spriteProvider.setPixel(xc + x, yc + y, color);
     spriteProvider.setPixel(xc - x, yc + y, color);
     spriteProvider.setPixel(xc + x, yc - y, color);
@@ -166,13 +151,7 @@ const Tools: React.FC<{
     spriteProvider.setPixel(xc - y, yc - x, color);
   };
 
-  const drawCircle = (
-    xc: number,
-    yc: number,
-    radius: number,
-    color: number,
-    fill = false,
-  ): void => {
+  const drawCircle = (xc: number, yc: number, radius: number, color: number, fill = false): void => {
     withBatch(() => {
       let x = radius;
       let y = 0;
@@ -303,25 +282,15 @@ const Tools: React.FC<{
       const move: CanvasHandler = (pos) => {
         const last = lastPosRef.current;
         if (!last) return;
-        const radius = Math.floor(
-          Math.sqrt((pos.x - last.x) ** 2 + (pos.y - last.y) ** 2),
-        );
+        const radius = Math.floor(Math.sqrt((pos.x - last.x) ** 2 + (pos.y - last.y) ** 2));
         previewRef.current = { center: last, radius };
       };
 
       const up: CanvasHandler = (pos) => {
         const last = lastPosRef.current;
         if (last) {
-          const radius = Math.floor(
-            Math.sqrt((pos.x - last.x) ** 2 + (pos.y - last.y) ** 2),
-          );
-          drawCircle(
-            last.x,
-            last.y,
-            radius,
-            colorRef.current,
-            fillCircleRef.current,
-          );
+          const radius = Math.floor(Math.sqrt((pos.x - last.x) ** 2 + (pos.y - last.y) ** 2));
+          drawCircle(last.x, last.y, radius, colorRef.current, fillCircleRef.current);
         } else {
           drawCircle(pos.x, pos.y, 1, colorRef.current, fillCircleRef.current);
         }
@@ -343,32 +312,25 @@ const Tools: React.FC<{
       // TODO: Implement line drawing
       return;
     }
-  }, [
-    drawTool,
-    setOnMouseDown,
-    setOnMouseMove,
-    setOnMouseUp,
-    setPreviewOverlay,
-    spriteProvider,
-  ]);
+  }, [drawTool, setOnMouseDown, setOnMouseMove, setOnMouseUp, setPreviewOverlay, spriteProvider]);
 
   return (
     <Container>
-      <ToolButton onClick={() => onSelectTool(DrawTool.Pen)}>Pen</ToolButton>
-      <ToolButton onClick={() => onSelectTool(DrawTool.Circle)}>
-        Circle
-      </ToolButton>
-      {drawTool === DrawTool.Circle && (
-        <label>
-          <input
-            type="checkbox"
-            checked={fillCircle}
-            onChange={(e) => setFillCircle(e.target.checked)}
-          />
-          Fill
-        </label>
-      )}
-      <ToolButton onClick={() => onSelectTool(DrawTool.Fill)}>Fill</ToolButton>
+      <ButtonRow>
+        <ToolButton onClick={() => onSelectTool(DrawTool.Pen)}>Pen</ToolButton>
+        <CircleGroup>
+          <ToolButton onClick={() => onSelectTool(DrawTool.Circle)}>Circle</ToolButton>
+          <label style={{ visibility: drawTool === DrawTool.Circle ? "visible" : "hidden" }}>
+            <input
+              type="checkbox"
+              checked={fillCircle}
+              onChange={(e) => setFillCircle(e.target.checked)}
+            />
+            Fill
+          </label>
+        </CircleGroup>
+        <ToolButton onClick={() => onSelectTool(DrawTool.Fill)}>Fill</ToolButton>
+      </ButtonRow>
     </Container>
   );
 };

--- a/src/modules/create/game-editor/editors/sprite-editor/Tools.tsx
+++ b/src/modules/create/game-editor/editors/sprite-editor/Tools.tsx
@@ -1,11 +1,20 @@
-import { CanvasHandler, DrawTool, PreviewOverlay } from "@modules/create/game-editor/editors/sprite-editor/SpriteEditor";
+import {
+  CanvasHandler,
+  DrawTool,
+  PreviewOverlay,
+} from "@modules/create/game-editor/editors/sprite-editor/SpriteEditor";
 import { SpriteProvider } from "@providers/editors/SpriteProvider";
 
 import React, { useEffect, useRef, useState } from "react";
 
 import { styled } from "@mui/material";
 
-export type SpritePixelAccessor = Pick<SpriteProvider, "isPixelInBounds" | "getPixel" | "setPixel">;
+export type SpritePixelAccessor = Pick<
+  SpriteProvider,
+  "isPixelInBounds" | "getPixel" | "setPixel"
+> & {
+  transact?: (fn: () => void) => void;
+};
 
 const Container = styled("div")(() => ({
   display: "flex",
@@ -28,7 +37,16 @@ const Tools: React.FC<{
   setOnMouseUp?: (fn: CanvasHandler) => void;
   setOnMouseDown?: (fn: CanvasHandler) => void;
   setPreviewOverlay?: (fn: PreviewOverlay | null) => void;
-}> = ({ drawTool, onSelectTool, setOnMouseDown, setOnMouseMove, setOnMouseUp, setPreviewOverlay, spriteProvider, color }) => {
+}> = ({
+  drawTool,
+  onSelectTool,
+  setOnMouseDown,
+  setOnMouseMove,
+  setOnMouseUp,
+  setPreviewOverlay,
+  spriteProvider,
+  color,
+}) => {
   const lastPosRef = useRef<Point2D | null>(null);
   const colorRef = useRef(color);
   const [fillCircle, setFillCircle] = useState(false);
@@ -43,7 +61,14 @@ const Tools: React.FC<{
     fillCircleRef.current = fillCircle;
   }, [fillCircle]);
 
-  // FIX IT TO MAKE IT WORK PROPERLY ON COLLABORATIVE EDITING
+  const withBatch = (fn: () => void): void => {
+    if (spriteProvider.transact) {
+      spriteProvider.transact(fn);
+    } else {
+      fn();
+    }
+  };
+
   const floodFillAt = (sx: number, sy: number, newColor: number): void => {
     if (!spriteProvider.isPixelInBounds(sx, sy)) {
       return;
@@ -52,6 +77,7 @@ const Tools: React.FC<{
     const startColor = spriteProvider.getPixel(sx, sy);
     if (startColor === newColor) return;
 
+    const toFill: [number, number][] = [];
     const stack: [number, number][] = [[sx, sy]];
     const visited = new Set<string>();
 
@@ -66,7 +92,7 @@ const Tools: React.FC<{
       const curColor = spriteProvider.getPixel(x, y);
       if (curColor !== startColor) continue;
 
-      spriteProvider.setPixel(x, y, newColor);
+      toFill.push([x, y]);
 
       stack.push([x + 1, y]);
       stack.push([x - 1, y]);
@@ -74,9 +100,14 @@ const Tools: React.FC<{
       stack.push([x, y - 1]);
     }
 
+    withBatch(() => {
+      for (const [x, y] of toFill) {
+        spriteProvider.setPixel(x, y, newColor);
+      }
+    });
   };
 
-  const drawLine = (a: Point2D, b: Point2D) : void => {
+  const drawLine = (a: Point2D, b: Point2D): void => {
     let x0 = a.x | 0;
     let y0 = a.y | 0;
     const x1 = b.x | 0;
@@ -87,31 +118,44 @@ const Tools: React.FC<{
     const sy = y0 < y1 ? 1 : -1;
     let err = dx - dy;
 
-    while (true) {
-      if (spriteProvider.getPixel(x0, y0) !== colorRef.current) {
-        spriteProvider.setPixel(x0, y0, colorRef.current);
-      }
+    withBatch(() => {
+      while (true) {
+        if (spriteProvider.getPixel(x0, y0) !== colorRef.current) {
+          spriteProvider.setPixel(x0, y0, colorRef.current);
+        }
 
-      if (x0 === x1 && y0 === y1) break;
-      const e2 = err * 2;
-      if (e2 > -dy) {
-        err -= dy;
-        x0 += sx;
+        if (x0 === x1 && y0 === y1) break;
+        const e2 = err * 2;
+        if (e2 > -dy) {
+          err -= dy;
+          x0 += sx;
+        }
+        if (e2 < dx) {
+          err += dx;
+          y0 += sy;
+        }
       }
-      if (e2 < dx) {
-        err += dx;
-        y0 += sy;
-      }
-    }
+    });
   };
 
-  const drawHLine = (x1: number, x2: number, y: number, color: number): void => {
+  const drawHLine = (
+    x1: number,
+    x2: number,
+    y: number,
+    color: number,
+  ): void => {
     for (let x = x1; x <= x2; x++) {
       spriteProvider.setPixel(x, y, color);
     }
   };
 
-  const plotCirclePoints = (xc: number, yc: number, x: number, y: number, color: number): void => {
+  const plotCirclePoints = (
+    xc: number,
+    yc: number,
+    x: number,
+    y: number,
+    color: number,
+  ): void => {
     spriteProvider.setPixel(xc + x, yc + y, color);
     spriteProvider.setPixel(xc - x, yc + y, color);
     spriteProvider.setPixel(xc + x, yc - y, color);
@@ -122,28 +166,36 @@ const Tools: React.FC<{
     spriteProvider.setPixel(xc - y, yc - x, color);
   };
 
-  const drawCircle = (xc: number, yc: number, radius: number, color: number, fill = false): void => {
-    let x = radius;
-    let y = 0;
-    let err = 1 - radius;
+  const drawCircle = (
+    xc: number,
+    yc: number,
+    radius: number,
+    color: number,
+    fill = false,
+  ): void => {
+    withBatch(() => {
+      let x = radius;
+      let y = 0;
+      let err = 1 - radius;
 
-    while (x >= y) {
-      if (fill) {
-        drawHLine(xc - x, xc + x, yc + y, color);
-        drawHLine(xc - y, xc + y, yc + x, color);
-        drawHLine(xc - x, xc + x, yc - y, color);
-        drawHLine(xc - y, xc + y, yc - x, color);
-      } else {
-        plotCirclePoints(xc, yc, x, y, color);
+      while (x >= y) {
+        if (fill) {
+          drawHLine(xc - x, xc + x, yc + y, color);
+          drawHLine(xc - y, xc + y, yc + x, color);
+          drawHLine(xc - x, xc + x, yc - y, color);
+          drawHLine(xc - y, xc + y, yc - x, color);
+        } else {
+          plotCirclePoints(xc, yc, x, y, color);
+        }
+        y++;
+        if (err < 0) {
+          err += 2 * y + 1;
+        } else {
+          x--;
+          err += 2 * (y - x) + 1;
+        }
       }
-      y++;
-      if (err < 0) {
-        err += 2 * y + 1;
-      } else {
-        x--;
-        err += 2 * (y - x) + 1;
-      }
-    }
+    });
   };
 
   useEffect(() => {
@@ -235,7 +287,10 @@ const Tools: React.FC<{
           }
           y++;
           if (err < 0) err += 2 * y + 1;
-          else { x--; err += 2 * (y - x) + 1; }
+          else {
+            x--;
+            err += 2 * (y - x) + 1;
+          }
         }
       };
       setPreviewOverlay?.(overlayFn);
@@ -248,15 +303,25 @@ const Tools: React.FC<{
       const move: CanvasHandler = (pos) => {
         const last = lastPosRef.current;
         if (!last) return;
-        const radius = Math.floor(Math.sqrt((pos.x - last.x) ** 2 + (pos.y - last.y) ** 2));
+        const radius = Math.floor(
+          Math.sqrt((pos.x - last.x) ** 2 + (pos.y - last.y) ** 2),
+        );
         previewRef.current = { center: last, radius };
       };
 
       const up: CanvasHandler = (pos) => {
         const last = lastPosRef.current;
         if (last) {
-          const radius = Math.floor(Math.sqrt((pos.x - last.x) ** 2 + (pos.y - last.y) ** 2));
-          drawCircle(last.x, last.y, radius, colorRef.current, fillCircleRef.current);
+          const radius = Math.floor(
+            Math.sqrt((pos.x - last.x) ** 2 + (pos.y - last.y) ** 2),
+          );
+          drawCircle(
+            last.x,
+            last.y,
+            radius,
+            colorRef.current,
+            fillCircleRef.current,
+          );
         } else {
           drawCircle(pos.x, pos.y, 1, colorRef.current, fillCircleRef.current);
         }
@@ -278,13 +343,21 @@ const Tools: React.FC<{
       // TODO: Implement line drawing
       return;
     }
-
-  }, [drawTool, setOnMouseDown, setOnMouseMove, setOnMouseUp, setPreviewOverlay, spriteProvider]);
+  }, [
+    drawTool,
+    setOnMouseDown,
+    setOnMouseMove,
+    setOnMouseUp,
+    setPreviewOverlay,
+    spriteProvider,
+  ]);
 
   return (
     <Container>
       <ToolButton onClick={() => onSelectTool(DrawTool.Pen)}>Pen</ToolButton>
-      <ToolButton onClick={() => onSelectTool(DrawTool.Circle)}>Circle</ToolButton>
+      <ToolButton onClick={() => onSelectTool(DrawTool.Circle)}>
+        Circle
+      </ToolButton>
       {drawTool === DrawTool.Circle && (
         <label>
           <input
@@ -295,8 +368,7 @@ const Tools: React.FC<{
           Fill
         </label>
       )}
-      {/* FILL commented because not working properly on collaborative editing */}
-      {/* <button className={drawTool === DrawTool.Fill ? "active" : ""} onClick={() => onSelectTool(DrawTool.Fill)}>Fill</button> */}
+      <ToolButton onClick={() => onSelectTool(DrawTool.Fill)}>Fill</ToolButton>
     </Container>
   );
 };

--- a/src/modules/create/game-editor/types/YSpriteSheet.ts
+++ b/src/modules/create/game-editor/types/YSpriteSheet.ts
@@ -5,7 +5,12 @@ export class YSpriteSheet {
   private readonly _width: number;
   private readonly _height: number;
 
-  constructor(doc: Y.Doc, name: string, width: number = 128, height: number = 128) {
+  constructor(
+    doc: Y.Doc,
+    name: string,
+    width: number = 128,
+    height: number = 128,
+  ) {
     this._spriteMap = doc.getMap<number>(name);
     this._width = width;
     this._height = height;

--- a/src/modules/create/game-editor/types/YSpriteSheet.ts
+++ b/src/modules/create/game-editor/types/YSpriteSheet.ts
@@ -5,12 +5,7 @@ export class YSpriteSheet {
   private readonly _width: number;
   private readonly _height: number;
 
-  constructor(
-    doc: Y.Doc,
-    name: string,
-    width: number = 128,
-    height: number = 128,
-  ) {
+  constructor(doc: Y.Doc, name: string, width: number = 128, height: number = 128) {
     this._spriteMap = doc.getMap<number>(name);
     this._width = width;
     this._height = height;

--- a/src/providers/ProjectProvider.ts
+++ b/src/providers/ProjectProvider.ts
@@ -6,7 +6,7 @@ import {
   WebRtcOfferDto,
   workSessionControllerGetInfo,
   workSessionControllerJoin,
-  workSessionControllerKick
+  workSessionControllerKick,
 } from "@api";
 import { seedDefaultProjectContent } from "@shared/project/defaultProjectContent";
 import { LocalStorageManager } from "@utils/LocalStorageManager";
@@ -26,7 +26,7 @@ import * as Y from "yjs";
 
 export enum ProviderEventType {
   INITIALIZED,
-  BECOME_HOST
+  BECOME_HOST,
 }
 
 export class ProjectProvider implements Destroyable {
@@ -69,14 +69,28 @@ export class ProjectProvider implements Destroyable {
         return;
       }
 
-      this._yjsProvider = new WebrtcProvider(this._roomId as string, this._yjsDoc, webrtcOffer! as ProviderOptions);
+      this._yjsProvider = new WebrtcProvider(
+        this._roomId as string,
+        this._yjsDoc,
+        webrtcOffer! as ProviderOptions,
+      );
 
-      this.awarenessProvider           = new AwarenessProvider(this, this._yjsProvider);
-      this.codeProvider                = new CodeProvider(this._yjsDoc, this.awarenessProvider);
-      this.spriteProvider              = new SpriteProvider(this._yjsDoc);
-      this.mapProvider                 = new MapProvider(this._yjsDoc, { width:128, height:32 }, 2, this.spriteProvider);
-      this.multiplayerSettingsProvider = new MultiplayerSettingsProvider(this._yjsDoc);
-      this.soundProvider               = new SoundProvider(this._yjsDoc);
+      this.awarenessProvider = new AwarenessProvider(this, this._yjsProvider);
+      this.codeProvider = new CodeProvider(
+        this._yjsDoc,
+        this.awarenessProvider,
+      );
+      this.spriteProvider = new SpriteProvider(this._yjsDoc);
+      this.mapProvider = new MapProvider(
+        this._yjsDoc,
+        { width: 128, height: 32 },
+        2,
+        this.spriteProvider,
+      );
+      this.multiplayerSettingsProvider = new MultiplayerSettingsProvider(
+        this._yjsDoc,
+      );
+      this.soundProvider = new SoundProvider(this._yjsDoc);
 
       this._initialized = true;
       this.emit(ProviderEventType.INITIALIZED);
@@ -89,37 +103,43 @@ export class ProjectProvider implements Destroyable {
 
     try {
       const { data: session } = await workSessionControllerJoin({
-        path: { id: this.projectId }
+        path: { id: this.projectId },
       });
 
-      console.log(`Joined work session ${session!.roomId} for project ID ${this.projectId}`);
+      console.log(
+        `Joined work session ${session!.roomId} for project ID ${this.projectId}`,
+      );
 
       this._roomId = session!.roomId;
 
       const userId = LocalStorageManager.getUserId();
       this.isHost = session!.hostId === userId;
 
-      const { data: projectContent } = await projectControllerFetchProjectContent({
-        path: { id: String(this.projectId) }
-      });
+      const { data: projectContent } =
+        await projectControllerFetchProjectContent({
+          path: { id: String(this.projectId) },
+        });
 
       console.log("Fetched project content");
 
-      if (projectContent!.size > 0) {
-        await decodeUpdate(this._yjsDoc, projectContent!);
-
+      if (projectContent !== undefined && projectContent.size > 0) {
+        await decodeUpdate(this._yjsDoc, projectContent);
         console.log("Project content decoded successfully");
+      } else {
+        console.log("No existing project content, seeding default content");
       }
 
       seedDefaultProjectContent(this._yjsDoc);
 
-      const { data: projectDetails } = (await projectControllerFindOne({
-        path: { id: this.projectId }
-      }));
+      const { data: projectDetails } = await projectControllerFindOne({
+        path: { id: this.projectId },
+      });
 
       this.projectSettingsProvider.updateName(projectDetails!.name);
       this.projectSettingsProvider.updateShortDesc(projectDetails!.shortDesc);
-      this.projectSettingsProvider.updateLongDesc(projectDetails!.longDesc ?? JSON.stringify(projectDetails!.longDesc));
+      this.projectSettingsProvider.updateLongDesc(
+        projectDetails!.longDesc ?? JSON.stringify(projectDetails!.longDesc),
+      );
       this.projectSettingsProvider.updateTags(projectDetails!.tags ?? []);
 
       await this.saveContent();
@@ -154,11 +174,12 @@ export class ProjectProvider implements Destroyable {
   }
 
   public async saveContent(): Promise<void> {
-    if (!this.isHost)
-      return;
+    if (!this.isHost) return;
     const data = encodeUpdate(this._yjsDoc);
 
-    const details = (await projectControllerFindOne({ path: { id: this.projectId } })).data!;
+    const details = (
+      await projectControllerFindOne({ path: { id: this.projectId } })
+    ).data!;
 
     const settings = this.projectSettingsProvider.getSettings();
 
@@ -184,7 +205,11 @@ export class ProjectProvider implements Destroyable {
 
     await projectControllerSaveProjectContent({
       path: { id: this.projectId },
-      body: { file: new Blob([data as BlobPart], { type: "application/octet-stream" }) },
+      body: {
+        file: new Blob([data as BlobPart], {
+          type: "application/octet-stream",
+        }),
+      },
     });
   }
 
@@ -200,9 +225,8 @@ export class ProjectProvider implements Destroyable {
     this._contentListeners.delete(callback);
   }
 
-  public async checkAndKickDisconnectedUsers() : Promise<void> {
-    if (this.isHost || this._isKicking || !this.awarenessProvider)
-      return;
+  public async checkAndKickDisconnectedUsers(): Promise<void> {
+    if (this.isHost || this._isKicking || !this.awarenessProvider) return;
 
     this._isKicking = true;
 
@@ -210,14 +234,18 @@ export class ProjectProvider implements Destroyable {
 
     const projectId = Number(this.projectId);
     try {
-      const sessionInfo = (await workSessionControllerGetInfo({ path: { id: projectId } })).data!;
+      const sessionInfo = (
+        await workSessionControllerGetInfo({ path: { id: projectId } })
+      ).data!;
 
       if (!this.isHost && sessionInfo.hostId === userId) {
         this.isHost = true;
         this.emit(ProviderEventType.BECOME_HOST);
       }
 
-      const connectedClients = Array.from(this.awarenessProvider?.getStates().keys() || []);
+      const connectedClients = Array.from(
+        this.awarenessProvider?.getStates().keys() || [],
+      );
       if (
         connectedClients.length === 1 &&
         this.awarenessProvider?.getClientId() !== undefined &&
@@ -226,7 +254,10 @@ export class ProjectProvider implements Destroyable {
         const users = sessionInfo.users || [];
         for (const sessionUserId of users) {
           if (Number(sessionUserId) !== userId) {
-            await workSessionControllerKick({ path: { id: projectId }, body: { userId: Number(sessionUserId) } });
+            await workSessionControllerKick({
+              path: { id: projectId },
+              body: { userId: Number(sessionUserId) },
+            });
           }
         }
         if (!this.isHost) {
@@ -239,7 +270,7 @@ export class ProjectProvider implements Destroyable {
     }
 
     this._isKicking = false;
-  };
+  }
 
   public observe(event: ProviderEventType, callback: () => void): void {
     if (!this._listeners.has(event)) {
@@ -257,6 +288,6 @@ export class ProjectProvider implements Destroyable {
   }
 
   emit(event: ProviderEventType): void {
-    this._listeners.get(event)?.forEach(callback => callback());
+    this._listeners.get(event)?.forEach((callback) => callback());
   }
 }

--- a/src/providers/ProjectProvider.ts
+++ b/src/providers/ProjectProvider.ts
@@ -69,27 +69,13 @@ export class ProjectProvider implements Destroyable {
         return;
       }
 
-      this._yjsProvider = new WebrtcProvider(
-        this._roomId as string,
-        this._yjsDoc,
-        webrtcOffer! as ProviderOptions,
-      );
+      this._yjsProvider = new WebrtcProvider(this._roomId as string, this._yjsDoc, webrtcOffer! as ProviderOptions);
 
       this.awarenessProvider = new AwarenessProvider(this, this._yjsProvider);
-      this.codeProvider = new CodeProvider(
-        this._yjsDoc,
-        this.awarenessProvider,
-      );
+      this.codeProvider = new CodeProvider(this._yjsDoc, this.awarenessProvider);
       this.spriteProvider = new SpriteProvider(this._yjsDoc);
-      this.mapProvider = new MapProvider(
-        this._yjsDoc,
-        { width: 128, height: 32 },
-        2,
-        this.spriteProvider,
-      );
-      this.multiplayerSettingsProvider = new MultiplayerSettingsProvider(
-        this._yjsDoc,
-      );
+      this.mapProvider = new MapProvider(this._yjsDoc, { width: 128, height: 32 }, 2, this.spriteProvider);
+      this.multiplayerSettingsProvider = new MultiplayerSettingsProvider(this._yjsDoc);
       this.soundProvider = new SoundProvider(this._yjsDoc);
 
       this._initialized = true;
@@ -106,9 +92,7 @@ export class ProjectProvider implements Destroyable {
         path: { id: this.projectId },
       });
 
-      console.log(
-        `Joined work session ${session!.roomId} for project ID ${this.projectId}`,
-      );
+      console.log(`Joined work session ${session!.roomId} for project ID ${this.projectId}`);
 
       this._roomId = session!.roomId;
 
@@ -137,9 +121,7 @@ export class ProjectProvider implements Destroyable {
 
       this.projectSettingsProvider.updateName(projectDetails!.name);
       this.projectSettingsProvider.updateShortDesc(projectDetails!.shortDesc);
-      this.projectSettingsProvider.updateLongDesc(
-        projectDetails!.longDesc ?? JSON.stringify(projectDetails!.longDesc),
-      );
+      this.projectSettingsProvider.updateLongDesc(projectDetails!.longDesc ?? JSON.stringify(projectDetails!.longDesc));
       this.projectSettingsProvider.updateTags(projectDetails!.tags ?? []);
 
       await this.saveContent();
@@ -174,12 +156,12 @@ export class ProjectProvider implements Destroyable {
   }
 
   public async saveContent(): Promise<void> {
-    if (!this.isHost) return;
+    if (!this.isHost) {
+      return;
+    }
     const data = encodeUpdate(this._yjsDoc);
 
-    const details = (
-      await projectControllerFindOne({ path: { id: this.projectId } })
-    ).data!;
+    const details = (await projectControllerFindOne({ path: { id: this.projectId } })).data!;
 
     const settings = this.projectSettingsProvider.getSettings();
 
@@ -226,7 +208,9 @@ export class ProjectProvider implements Destroyable {
   }
 
   public async checkAndKickDisconnectedUsers(): Promise<void> {
-    if (this.isHost || this._isKicking || !this.awarenessProvider) return;
+    if (this.isHost || this._isKicking || !this.awarenessProvider) {
+      return;
+    }
 
     this._isKicking = true;
 
@@ -234,18 +218,14 @@ export class ProjectProvider implements Destroyable {
 
     const projectId = Number(this.projectId);
     try {
-      const sessionInfo = (
-        await workSessionControllerGetInfo({ path: { id: projectId } })
-      ).data!;
+      const sessionInfo = (await workSessionControllerGetInfo({ path: { id: projectId } })).data!;
 
       if (!this.isHost && sessionInfo.hostId === userId) {
         this.isHost = true;
         this.emit(ProviderEventType.BECOME_HOST);
       }
 
-      const connectedClients = Array.from(
-        this.awarenessProvider?.getStates().keys() || [],
-      );
+      const connectedClients = Array.from(this.awarenessProvider?.getStates().keys() || []);
       if (
         connectedClients.length === 1 &&
         this.awarenessProvider?.getClientId() !== undefined &&

--- a/src/providers/editors/ProjectSettingsProvider.ts
+++ b/src/providers/editors/ProjectSettingsProvider.ts
@@ -21,6 +21,8 @@ export class ProjectSettingsProvider implements Destroyable {
 
   private readonly _boundCallListeners: () => void;
 
+  private _isDestroyed = false;
+
   constructor(ydoc: Y.Doc) {
     this._projectNameContent = ydoc.getText("projectName");
     this._shortDescContent = ydoc.getText("shortDescription");
@@ -36,6 +38,8 @@ export class ProjectSettingsProvider implements Destroyable {
   }
 
   destroy(): void {
+    if (this._isDestroyed) return;
+    this._isDestroyed = true;
     this._listeners.clear();
     this._projectNameContent.unobserve(this._boundCallListeners);
     this._shortDescContent.unobserve(this._boundCallListeners);

--- a/src/providers/editors/SpriteProvider.ts
+++ b/src/providers/editors/SpriteProvider.ts
@@ -23,17 +23,12 @@ export class SpriteProvider implements Destroyable {
   public readonly stride: number = 1;
   public readonly spriteCount: number;
 
-  constructor(
-    doc: Y.Doc,
-    spriteSize: Size = { width: 8, height: 8 },
-    size: Size = { width: 128, height: 128 },
-  ) {
+  constructor(doc: Y.Doc, spriteSize: Size = { width: 8, height: 8 }, size: Size = { width: 128, height: 128 }) {
     this._spriteMap = doc.getMap<number>("sprite");
     this._spriteFlags = doc.getMap<number>("sprite_flags");
     this.spriteSize = spriteSize;
     this.size = size;
-    this.spriteCount =
-      (size.width / spriteSize.width) * (size.height / spriteSize.height);
+    this.spriteCount = (size.width / spriteSize.width) * (size.height / spriteSize.height);
 
     this.palette = webglPaletteBuffer;
     this._boundCallListeners = this._callListeners.bind(this);

--- a/src/providers/editors/SpriteProvider.ts
+++ b/src/providers/editors/SpriteProvider.ts
@@ -1,7 +1,10 @@
 import { SpriteProviderError } from "@errors/SpriteProviderError";
-import { palette } from "@shared/placeholders/spriteSheet";
+import { webglPaletteBuffer } from "@modules/create/game-editor/editors/sprite-editor/Color";
 
 import * as Y from "yjs";
+
+export type PixelChange = { x: number; y: number; color: number };
+export type SpriteContentListener = (changes: PixelChange[]) => void;
 
 type SpriteFlagListener = (flags: number[]) => void;
 
@@ -9,9 +12,9 @@ export class SpriteProvider implements Destroyable {
   private _spriteMap: Y.Map<number>;
   private _spriteFlags: Y.Map<number>;
   private _rawListeners = new Set<RawContentListener>();
-  private _listeners = new Set<ContentListener>();
+  private _listeners = new Set<SpriteContentListener>();
   private _flagListeners = new Set<SpriteFlagListener>();
-  private readonly _boundCallListeners: () => void;
+  private readonly _boundCallListeners: (event: Y.YMapEvent<number>) => void;
   private readonly _boundCallFlagListeners: () => void;
 
   public palette: Uint8Array;
@@ -20,14 +23,19 @@ export class SpriteProvider implements Destroyable {
   public readonly stride: number = 1;
   public readonly spriteCount: number;
 
-  constructor(doc: Y.Doc, spriteSize: Size = { width: 8, height: 8 }, size: Size = { width: 128, height: 128 }) {
+  constructor(
+    doc: Y.Doc,
+    spriteSize: Size = { width: 8, height: 8 },
+    size: Size = { width: 128, height: 128 },
+  ) {
     this._spriteMap = doc.getMap<number>("sprite");
     this._spriteFlags = doc.getMap<number>("sprite_flags");
     this.spriteSize = spriteSize;
     this.size = size;
-    this.spriteCount = (size.width / spriteSize.width) * (size.height / spriteSize.height);
+    this.spriteCount =
+      (size.width / spriteSize.width) * (size.height / spriteSize.height);
 
-    this.palette = palette;
+    this.palette = webglPaletteBuffer;
     this._boundCallListeners = this._callListeners.bind(this);
     this._boundCallFlagListeners = this._callFlagListeners.bind(this);
     this._spriteMap.observe(this._boundCallListeners);
@@ -42,12 +50,28 @@ export class SpriteProvider implements Destroyable {
     this._spriteFlags.unobserve(this._boundCallFlagListeners);
   }
 
-  private _callListeners(): void {
-    const content = this.getPixelBuffer();
-    this._listeners.forEach((callback) => callback(content));
+  private _callListeners(event: Y.YMapEvent<number>): void {
+    if (this._listeners.size > 0) {
+      const changes: PixelChange[] = [];
 
-    const rawContent = this.getHexRepresentation();
-    this._rawListeners.forEach((callback) => callback(rawContent));
+      event.changes.keys.forEach((_change, key) => {
+        const [xStr, yStr] = key.split(",");
+        const x = Number(xStr);
+        const y = Number(yStr);
+        const color = this._spriteMap.get(key) ?? 0;
+
+        changes.push({ x, y, color });
+      });
+
+      if (changes.length > 0) {
+        this._listeners.forEach((callback) => callback(changes));
+      }
+    }
+
+    if (this._rawListeners.size > 0) {
+      const rawContent = this.getHexRepresentation();
+      this._rawListeners.forEach((callback) => callback(rawContent));
+    }
   }
 
   private _callFlagListeners(): void {
@@ -74,14 +98,20 @@ export class SpriteProvider implements Destroyable {
 
   setPixel(x: number, y: number, color: number): void {
     const key = this._coordToKey(x, y);
-    if (color == 0)
-      this._spriteMap.delete(key); // Optimize network by deleting black pixels
+    if (color === 0) {
+      this._spriteMap.delete(key);
+      return;
+    }
     this._spriteMap.set(key, color);
   }
 
   deletePixel(x: number, y: number): void {
     const key = this._coordToKey(x, y);
     this._spriteMap.set(key, 0);
+  }
+
+  transact(fn: () => void): void {
+    this._spriteMap.doc!.transact(fn);
   }
 
   private _coordToKey(x: number, y: number): string {
@@ -173,8 +203,8 @@ export class SpriteProvider implements Destroyable {
     const normalizedBit = this._validateBitIndex(bit);
     const currentValue = this.getFlag(index);
     const nextValue = enabled
-      ? (currentValue | (1 << normalizedBit))
-      : (currentValue & ~(1 << normalizedBit));
+      ? currentValue | (1 << normalizedBit)
+      : currentValue & ~(1 << normalizedBit);
 
     this.setFlag(index, nextValue);
   }
@@ -189,7 +219,7 @@ export class SpriteProvider implements Destroyable {
     return flags;
   }
 
-  observe(callback: ContentListener): void {
+  observe(callback: SpriteContentListener): void {
     this._listeners.add(callback);
   }
 
@@ -199,5 +229,17 @@ export class SpriteProvider implements Destroyable {
 
   observeFlags(callback: SpriteFlagListener): void {
     this._flagListeners.add(callback);
+  }
+
+  unobserve(callback: SpriteContentListener): void {
+    this._listeners.delete(callback);
+  }
+
+  unobserveRaw(callback: RawContentListener): void {
+    this._rawListeners.delete(callback);
+  }
+
+  unobserveFlags(callback: SpriteFlagListener): void {
+    this._flagListeners.delete(callback);
   }
 }

--- a/src/shared/canvas/RendererHandle.ts
+++ b/src/shared/canvas/RendererHandle.ts
@@ -1,6 +1,6 @@
 import { CanvasError, CanvasNotInitializedError } from "@errors/CanvasError";
 import { MapProvider } from "@providers/editors/MapProvider";
-import { SpriteProvider } from "@providers/editors/SpriteProvider";
+import { PixelChange, SpriteProvider } from "@providers/editors/SpriteProvider";
 import { GLPipeline, initGLPipeline } from "@shared/canvas/GLSetup";
 import { rectangleToVertices } from "@shared/canvas/glUtils";
 
@@ -14,7 +14,7 @@ export type QueueSpriteDrawFn = (
   height?: number,
   flip_h?: number,
   flip_v?: number,
-  scale?: number
+  scale?: number,
 ) => void;
 
 export type SpriteRendererHandle = {
@@ -25,9 +25,27 @@ export type SpriteRendererHandle = {
   setColor: (index: number, index2: number) => void;
   resetColor: () => void;
   moveCamera: (x: number, y: number) => void;
-  drawLine: (col: number, x0: number, y0: number, x1: number, y1: number) => void;
-  drawOutlineRect: (col: number, x: number, y: number, width: number, height: number) => void;
-  drawRect: (col: number, x: number, y: number, width: number, height: number) => void;
+  drawLine: (
+    col: number,
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+  ) => void;
+  drawOutlineRect: (
+    col: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ) => void;
+  drawRect: (
+    col: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ) => void;
   getCanvas?: () => HTMLCanvasElement | null;
 };
 
@@ -35,7 +53,7 @@ export function useSpriteRenderer(
   canvasRef: React.RefObject<HTMLCanvasElement | null>,
   sprite: SpriteProvider,
   map: MapProvider,
-  screenSize: { width: number, height: number }
+  screenSize: { width: number; height: number },
 ): SpriteRendererHandle {
   const spriteNumber = sprite.size.width / sprite.spriteSize.width;
   const batchedVertices: number[] = [];
@@ -47,7 +65,9 @@ export function useSpriteRenderer(
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas) { throw new CanvasNotInitializedError(); }
+    if (!canvas) {
+      throw new CanvasNotInitializedError();
+    }
     pipelineRef.current = initGLPipeline(canvas, sprite, map, screenSize);
     if (!pipelineRef.current) {
       throw new CanvasNotInitializedError();
@@ -65,43 +85,75 @@ export function useSpriteRenderer(
 
     const gl = p.gl;
     gl.useProgram(p.program);
-    gl.viewport(0, 0, canvas.width, canvas.height);
+    gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
     gl.uniform2f(
       gl.getUniformLocation(p.program, "screen_resolution"),
       screenSize.width,
-      screenSize.height
+      screenSize.height,
     );
-
   }, [screenSize.width, screenSize.height]);
+
   useEffect(() => {
+    const spriteCallback = (changes: PixelChange[]): void => {
+      _refreshSpriteTexturePartial(changes);
+    };
+
     map.observe(() => {
       _refreshMapTexture();
     });
+    sprite.observe(spriteCallback);
 
-    sprite.observe(() => {
-      _refreshSpriteTexture();
-      _refreshMapTexture();
-    });
+    return () => {
+      sprite.unobserve(spriteCallback);
+    };
   }, [map, sprite]);
 
-  function _refreshSpriteTexture(): void {
+  function _refreshSpriteTexturePartial(changes: PixelChange[]): void {
     const p = pipelineRef.current;
-    if (!p) return;
+    if (!p || changes.length === 0) return;
 
     const gl = p.gl;
+
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+    for (const { x, y } of changes) {
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+
+    minX = Math.max(0, minX);
+    minY = Math.max(0, minY);
+    maxX = Math.min(sprite.size.width - 1, maxX);
+    maxY = Math.min(sprite.size.height - 1, maxY);
+
+    const width = maxX - minX + 1;
+    const height = maxY - minY + 1;
+    if (width <= 0 || height <= 0) return;
+
+    const region = new Uint8Array(width * height);
+    for (let y = minY; y <= maxY; y++) {
+      for (let x = minX; x <= maxX; x++) {
+        region[(y - minY) * width + (x - minX)] = sprite.getPixel(x, y);
+      }
+    }
+
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, p.spriteSheetTexture);
     gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
     gl.texSubImage2D(
       gl.TEXTURE_2D,
       0,
-      0,
-      0,
-      sprite.size.width,
-      sprite.size.height,
+      minX,
+      minY,
+      width,
+      height,
       gl.RED,
       gl.UNSIGNED_BYTE,
-      sprite.getU8PixelBuffer()
+      region,
     );
   }
 
@@ -122,7 +174,7 @@ export function useSpriteRenderer(
       map.height * sprite.spriteSize.height,
       gl.RED,
       gl.UNSIGNED_BYTE,
-      map.getU8PixelBuffer()
+      map.getU8PixelBuffer(),
     );
   }
 
@@ -134,7 +186,13 @@ export function useSpriteRenderer(
     const cameraPosLoc = p.cameraPosLoc;
     gl.uniform2f(cameraPosLoc, x, y);
   }
-  function drawLine(col: number, x0: number, y0: number, x1: number, y1: number): void {
+  function drawLine(
+    col: number,
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+  ): void {
     const p = pipelineRef.current;
     if (!p) return;
     const gl = p.gl;
@@ -148,14 +206,8 @@ export function useSpriteRenderer(
     const paletteSize = currentPalette.length / 4;
     const uvX = (col + 0.5) / paletteSize;
 
-    batchedUVs.push(
-      uvX, 0,
-      uvX, 0,
-    );
-    batchedVertices.push(
-      x0, y0,
-      x1, y1,
-    );
+    batchedUVs.push(uvX, 0, uvX, 0);
+    batchedVertices.push(x0, y0, x1, y1);
     gl.uniform1i(gl.getUniformLocation(p.program, "u_texture"), 1);
     gl.disable(gl.BLEND);
     drawForm(gl.LINES);
@@ -163,7 +215,13 @@ export function useSpriteRenderer(
     gl.uniform1i(gl.getUniformLocation(p.program, "u_texture"), 0);
   }
 
-  function drawOutlineRect(col: number, x: number, y: number, width: number, height: number): void {
+  function drawOutlineRect(
+    col: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ): void {
     const p = pipelineRef.current;
     if (!p) return;
     const gl = p.gl;
@@ -180,19 +238,9 @@ export function useSpriteRenderer(
     const x1 = x + width - 0.5;
     const y1 = y + height - 0.5;
 
-    batchedUVs.push(
-      uvX, 0,
-      uvX, 0,
-      uvX, 0,
-      uvX, 0,
-    );
+    batchedUVs.push(uvX, 0, uvX, 0, uvX, 0, uvX, 0);
 
-    batchedVertices.push(
-      x0, y0,
-      x1, y0,
-      x1, y1,
-      x0, y1,
-    );
+    batchedVertices.push(x0, y0, x1, y0, x1, y1, x0, y1);
     gl.uniform1i(gl.getUniformLocation(p.program, "u_texture"), 3);
     gl.disable(gl.BLEND);
     drawForm(gl.LINE_LOOP);
@@ -200,7 +248,13 @@ export function useSpriteRenderer(
     gl.uniform1i(gl.getUniformLocation(p.program, "u_texture"), 0);
   }
 
-  function drawRect(col: number, x: number, y: number, width: number, height: number): void {
+  function drawRect(
+    col: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ): void {
     const p = pipelineRef.current;
     if (!p) return;
     const gl = p.gl;
@@ -214,14 +268,7 @@ export function useSpriteRenderer(
     const paletteSize = currentPalette.length / 4;
     const uvX = (col + 0.5) / paletteSize;
 
-    batchedUVs.push(
-      uvX, 0,
-      uvX, 0,
-      uvX, 0,
-      uvX, 0,
-      uvX, 0,
-      uvX, 0,
-    );
+    batchedUVs.push(uvX, 0, uvX, 0, uvX, 0, uvX, 0, uvX, 0, uvX, 0);
     const verts = rectangleToVertices(x, y, width, height);
     batchedVertices.push(...verts);
 
@@ -253,12 +300,20 @@ export function useSpriteRenderer(
     if (batchedVertices.length === 0) return;
 
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(batchedVertices), gl.STREAM_DRAW);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array(batchedVertices),
+      gl.STREAM_DRAW,
+    );
     gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
     gl.enableVertexAttribArray(posLoc);
 
     gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(batchedUVs), gl.STREAM_DRAW);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array(batchedUVs),
+      gl.STREAM_DRAW,
+    );
     gl.vertexAttribPointer(uvLocation, 2, gl.FLOAT, false, 0, 0);
     gl.enableVertexAttribArray(uvLocation);
 
@@ -279,19 +334,12 @@ export function useSpriteRenderer(
     const gl = p.gl;
     const program = p.program;
     gl.uniform1i(gl.getUniformLocation(program, "u_texture"), 2);
-    const uv = new Float32Array([
-      0, 0,
-      1, 0,
-      0, 1,
-      0, 1,
-      1, 0,
-      1, 1,
-    ]);
+    const uv = new Float32Array([0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1]);
     const vertices = rectangleToVertices(
       x,
       y,
       map.width * sprite.spriteSize.width,
-      map.height * sprite.spriteSize.height
+      map.height * sprite.spriteSize.height,
     );
 
     batchedVertices.push(...vertices);
@@ -300,35 +348,46 @@ export function useSpriteRenderer(
     gl.uniform1i(gl.getUniformLocation(program, "u_texture"), 0);
   }
 
-  function queueSpriteDraw(index: number,
-    x: number, y: number,
-    width: number = 1, height: number = 1,
-    flip_h: number = 0, flip_v: number = 0,
-    scale: number = 1
+  function queueSpriteDraw(
+    index: number,
+    x: number,
+    y: number,
+    width: number = 1,
+    height: number = 1,
+    flip_h: number = 0,
+    flip_v: number = 0,
+    scale: number = 1,
   ): void {
     x = Math.floor(x);
     y = Math.floor(y);
     flip_h = flip_h ? 1 : 0;
     flip_v = flip_v ? 1 : 0;
 
-    const x_sprite = index % (spriteNumber);
-    const y_sprite = Math.floor(index / (spriteNumber));
+    const x_sprite = index % spriteNumber;
+    const y_sprite = Math.floor(index / spriteNumber);
 
-    let u0 = x_sprite * sprite.spriteSize.width / sprite.size.width;
-    let v0 = y_sprite * sprite.spriteSize.height / sprite.size.height;
-    let u1 = (x_sprite + width) * sprite.spriteSize.width / sprite.size.width;
-    let v1 = (y_sprite + height) * sprite.spriteSize.height / sprite.size.height;
+    let u0 = (x_sprite * sprite.spriteSize.width) / sprite.size.width;
+    let v0 = (y_sprite * sprite.spriteSize.height) / sprite.size.height;
+    let u1 = ((x_sprite + width) * sprite.spriteSize.width) / sprite.size.width;
+    let v1 =
+      ((y_sprite + height) * sprite.spriteSize.height) / sprite.size.height;
 
     if (flip_h) [u0, u1] = [u1, u0];
     if (flip_v) [v0, v1] = [v1, v0];
 
     const uv = new Float32Array([
-      u0, v0,
-      u1, v0,
-      u0, v1,
-      u0, v1,
-      u1, v0,
-      u1, v1,
+      u0,
+      v0,
+      u1,
+      v0,
+      u0,
+      v1,
+      u0,
+      v1,
+      u1,
+      v0,
+      u1,
+      v1,
     ]);
 
     const vertices = rectangleToVertices(
@@ -364,7 +423,10 @@ export function useSpriteRenderer(
     const distanceIndex = index * 4;
     const distanceIndex2 = index2 * 4;
 
-    if (distanceIndex >= currentPalette.length || distanceIndex2 >= sprite.palette.length) {
+    if (
+      distanceIndex >= currentPalette.length ||
+      distanceIndex2 >= sprite.palette.length
+    ) {
       throw new CanvasError("Palette index out of bounds");
     }
     currentPalette[distanceIndex] = sprite.palette[distanceIndex2];
@@ -376,12 +438,13 @@ export function useSpriteRenderer(
     gl.texSubImage2D(
       gl.TEXTURE_2D,
       0,
-      0, 0,
+      0,
+      0,
       currentPaletteSize,
       1,
       gl.RGBA,
       gl.UNSIGNED_BYTE,
-      currentPalette
+      currentPalette,
     );
   }
 
@@ -392,31 +455,37 @@ export function useSpriteRenderer(
     gl.texSubImage2D(
       gl.TEXTURE_2D,
       0,
-      0, 0,
+      0,
+      0,
       currentPaletteSize,
       1,
       gl.RGBA,
       gl.UNSIGNED_BYTE,
-      sprite.palette
+      sprite.palette,
     );
   }
 
   function _getPipeline(): GLPipeline {
     const p = pipelineRef.current;
-    if (!p) { throw new CanvasNotInitializedError(); }
+    if (!p) {
+      throw new CanvasNotInitializedError();
+    }
     return p;
   }
 
-  return useMemo(() => ({
-    queueSpriteDraw,
-    draw,
-    drawMap,
-    clear,
-    setColor,
-    resetColor,
-    moveCamera,
-    drawLine,
-    drawOutlineRect,
-    drawRect,
-  }), []);
+  return useMemo(
+    () => ({
+      queueSpriteDraw,
+      draw,
+      drawMap,
+      clear,
+      setColor,
+      resetColor,
+      moveCamera,
+      drawLine,
+      drawOutlineRect,
+      drawRect,
+    }),
+    [],
+  );
 }

--- a/src/shared/canvas/RendererHandle.ts
+++ b/src/shared/canvas/RendererHandle.ts
@@ -119,10 +119,10 @@ export function useSpriteRenderer(
       maxX = -Infinity,
       maxY = -Infinity;
     for (const { x, y } of changes) {
-      if (x < minX) minX = x;
-      if (x > maxX) maxX = x;
-      if (y < minY) minY = y;
-      if (y > maxY) maxY = y;
+      minX = Math.min(minX, x);
+      maxX = Math.max(maxX, x);
+      minY = Math.min(minY, y);
+      maxY = Math.max(maxY, y);
     }
 
     minX = Math.max(0, minX);


### PR DESCRIPTION
…ads and Yjs batch transactions, fix minimap and layout bugs

## Jira ticket  
https://naucto.atlassian.net/jira/software/projects/NCTO/boards/2/backlog?selectedIssue=NCTO-223&visitedUserSeg=true

## What does your MR do ?  
- Partial GPU texture uploads: SpriteProvider._callListeners now emits PixelChange[] (x, y, color per changed pixel) instead of serializing the full pixel buffer. RendererHandle uses texSubImage2D on the bounding box of changed pixels only, replacing the full-sheet upload on every change.
- Yjs batch transactions: Drawing tools (line, circle, flood fill) now wrap all pixel writes in a single transact() call. Remote peers receive one CRDT event per operation instead of one per pixel, reducing network traffic and keeping undo history clean.
- selection canvas only showing the drawn tile: drawSelectionTile was calling handle.draw() on a single queued sprite. Since WebGL uses preserveDrawingBuffer: false, the previous frame's content is discarded after compositing only the last drawn tile remained visible. Replaced with drawSelectionCanvas() (full redraw) on every change.
- tile grid misalignment after zoom: CanvasColumns was missing display: flex + flexDirection: column, breaking the height chain to the detail canvas. FillPanel now has flex: 1 and DetailCanvasViewport is a proper styled component
- selection minimap stretched: SpritePickerViewport was using height: 100% + aspectRatio: 1 inside a flex column, causing it to exceed its container width. Fixed with width: 100% (height derived from aspectRatio).
- type ambiguity ContentListener: SpriteProvider now exports SpriteContentListener (typed (changes: PixelChange[]) => void) to avoid collision with the global ContentListener = (content: number[]) => void in common.d.ts. RawContentListener usage restored (was accidentally renamed by a prior replace-all).
- HiDPI support: gl.viewport uses gl.drawingBufferWidth/Height instead of canvas.width/height.
- webglPaletteBuffer: Pre-computed Uint8Array of palette RGBA values in Color.tsx, shared with SpriteProvider to avoid repeated hex parsing.

## How to test it  


## Screenshot  


## Notes


