### PR TITLE
[FRONTEND] [ADD] Added a button in profile to set a new password !

### DIFF
--- a/src/modules/profile/ChangePasswordDialog.tsx
+++ b/src/modules/profile/ChangePasswordDialog.tsx
@@ -1,0 +1,89 @@
+import { authControllerChangePassword } from "@api";
+import { FullWidthTextField } from "@components/ui/FullWidthTextField";
+import ImportantButton from "@shared/buttons/ImportantButton";
+import { CustomDialog } from "@shared/dialog/CustomDialog";
+
+import { JSX } from "react";
+
+import { Typography } from "@mui/material";
+import { isAxiosError } from "axios";
+import { useSnackbar } from "notistack";
+import { useForm } from "react-hook-form";
+
+interface ChangePasswordFormValues {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const ChangePasswordDialog = ({ isOpen, onClose }: Props): JSX.Element => {
+  const { register, handleSubmit, reset, formState: { errors, isSubmitting } } = useForm<ChangePasswordFormValues>();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleClose = (): void => {
+    reset();
+    onClose();
+  };
+
+  const onSubmit = async (data: ChangePasswordFormValues): Promise<void> => {
+    try {
+      await authControllerChangePassword({
+        throwOnError: true,
+        body: {
+          currentPassword: data.currentPassword || undefined,
+          newPassword: data.newPassword,
+        },
+      });
+      enqueueSnackbar("Password updated successfully", { variant: "success" });
+      handleClose();
+    } catch (error) {
+      if (isAxiosError(error)) {
+        const message = error.response?.data?.message ?? "An error occurred while updating the password";
+        enqueueSnackbar(message, { variant: "error" });
+      } else {
+        enqueueSnackbar("An unexpected error occurred", { variant: "error" });
+      }
+    }
+  };
+
+  return (
+    <CustomDialog isOpen={isOpen} setIsOpen={(open) => { if (!open) handleClose(); }} hideSubmitButton>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Typography variant="h6" sx={{ mb: 1 }}>Change password</Typography>
+        <FullWidthTextField
+          label="Current password"
+          type="password"
+          helperText="Leave empty if you signed in with Google, GitHub, or Microsoft"
+          {...register("currentPassword")}
+        />
+        <FullWidthTextField
+          label="New password"
+          type="password"
+          error={!!errors.newPassword}
+          helperText={errors.newPassword?.message}
+          {...register("newPassword", { required: "New password is required" })}
+        />
+        <FullWidthTextField
+          label="Confirm new password"
+          type="password"
+          error={!!errors.confirmPassword}
+          helperText={errors.confirmPassword?.message}
+          {...register("confirmPassword", {
+            required: "Please confirm your new password",
+            validate: (value, formValues) => value === formValues.newPassword || "Passwords do not match",
+          })}
+        />
+        <ImportantButton type="submit" fullWidth sx={{ mt: 1 }} disabled={isSubmitting}>
+          Update password
+        </ImportantButton>
+      </form>
+    </CustomDialog>
+  );
+};
+
+export default ChangePasswordDialog;

--- a/src/modules/profile/Profile.tsx
+++ b/src/modules/profile/Profile.tsx
@@ -15,6 +15,8 @@ import { Editable } from "@shared/forms/Editable";
 import * as urls from "@shared/navigation/routes";
 import { LocalStorageManager } from "@utils/LocalStorageManager";
 
+import { ChangePasswordDialog } from "./ChangePasswordDialog";
+
 import { JSX, useEffect, useMemo, useRef, useState } from "react";
 
 import { Box, Typography } from "@mui/material";
@@ -152,6 +154,7 @@ export const Profile = (): JSX.Element => {
   const { username } = useParams<{ username?: string }>();
   const userId = Number(LocalStorageManager.getUserId());
   const [isEditing, setIsEditing] = useState(false);
+  const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
   const [refresh, setRefresh] = useState(1);
   const [selectedProfileFile, setSelectedProfileFile] = useState<File | null>(null);
   const [selectedBackgroundFile, setSelectedBackgroundFile] = useState<File | null>(null);
@@ -370,6 +373,11 @@ export const Profile = (): JSX.Element => {
                   </EditProfileButton>
                 )}
                 {isEditable && isEditing && <EditProfileButton type="submit">Submit</EditProfileButton>}
+                {isEditable && (
+                  <EditProfileButton type="button" onClick={() => setIsPasswordDialogOpen(true)}>
+                    Change password
+                  </EditProfileButton>
+                )}
               </HorizontalBox>
             </TextInfo>
           </ProfileInfo>
@@ -407,6 +415,7 @@ export const Profile = (): JSX.Element => {
           </HorizontalScroller>
         </Section>
       </form>
+      <ChangePasswordDialog isOpen={isPasswordDialogOpen} onClose={() => setIsPasswordDialogOpen(false)} />
     </>
   );
 };

--- a/src/shared/user/UserProfileLink.tsx
+++ b/src/shared/user/UserProfileLink.tsx
@@ -99,7 +99,7 @@ const AvatarStackRoot = styled("span", {
     borderRadius: "50%",
     transition: "margin-left 0.18s ease, transform 0.18s ease",
   },
-  "& .NauctoUserAvatarStack-item:first-child": {
+  "& .NauctoUserAvatarStack-item:first-of-type": {
     marginLeft: 0,
   },
   "& .NauctoUserAvatarStack-hiddenUser": {
@@ -108,7 +108,7 @@ const AvatarStackRoot = styled("span", {
   "&:hover .NauctoUserAvatarStack-item": {
     marginLeft: theme.spacing(0.2),
   },
-  "&:hover .NauctoUserAvatarStack-item:first-child": {
+  "&:hover .NauctoUserAvatarStack-item:first-of-type": {
     marginLeft: 0,
   },
   "&:hover .NauctoUserAvatarStack-hiddenUser": {


### PR DESCRIPTION
## Jira ticket  
https://naucto.atlassian.net/jira/software/projects/NCTO/boards/2/backlog?selectedIssue=NCTO-241

## What does your MR do ?  
If a user logs in using [Google, Github, Microsoft), they won't be able to login using a password, because the password is not yet set. I added a button in the profile to change the password, using the PATCH route in the backend that was already implemented long ago.
Using this, any user can change their password if needed, and set a password if none.

## How to test it  


## Screenshot  
<img width="1280" height="720" alt="profile-01-boutons" src="https://github.com/user-attachments/assets/f83d70ce-7b60-4881-b316-e03dcc75a87f" />
<img width="1280" height="720" alt="profile-02-dialog" src="https://github.com/user-attachments/assets/305288bf-5ed0-4f96-b5d7-8f686eb41b51" />
<img width="1280" height="720" alt="profile-03-validation-mismatch" src="https://github.com/user-attachments/assets/f4097103-ccfd-4833-9d96-b203dde9ee4b" />
<img width="1280" height="720" alt="profile-04-succes" src="https://github.com/user-attachments/assets/148bf5e0-3d12-4902-a6cc-cced046b15b7" />


## Notes  



